### PR TITLE
Fix links in subheader

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
 	<hgroup>
 		<h1>HTML5 &lt;progress&gt; polyfill</h1>
-		<h2><a href="http://leaverou.me">by Lea Verou</a> &bull; <a href="http://leaverou.me/2011/07/a-polyfill-for-html5-progress-element">Story</a> &bull; <a href="https://github.com/LeaVerou/HTML5-Progress-polyfill">Github</a></h2>
+		<h2><a href="http://lea.verou.me">by Lea Verou</a> &bull; <a href="http://lea.verou.me/2011/07/a-polyfill-for-html5-progress-element">Story</a> &bull; <a href="https://github.com/LeaVerou/HTML5-Progress-polyfill">Github</a></h2>
 	</hgroup>
 	
 	<h2>Demos</h2>


### PR DESCRIPTION
Links go to [leaverou.me](http://leaverou.me) instead of [lea.verou.me](http://lea.verou.me). Don't know if you originally owned that domain, but it seems to be up for sale now...?

