### PR TITLE
Fix for setting value greater than max

### DIFF
--- a/progress-polyfill.js
+++ b/progress-polyfill.js
@@ -103,6 +103,9 @@ var self = window.ProgressPolyfill = {
 			},
 			
 			set: function(value) {
+				if (value > this.max){
+					value = this.max;
+				}
 				this.setAttribute('aria-valuenow', value);
 				
 				if(!attrsAsProps) {


### PR DESCRIPTION
if you try and set the value greater than the max the progress will set the value, this has knock on effects for position and the style.

I tested the behaviour in Chrome, attempting to set a value greater than max results in max being used instead.